### PR TITLE
Fix trying multiple mo-files if one is not found

### DIFF
--- a/language-fallback.php
+++ b/language-fallback.php
@@ -74,14 +74,11 @@ class Language_Fallback {
 			// try to get a fallback for the locale
 			foreach( $fallback_locales as $fallback_locale ) {
 
-				$mofile = str_replace( $this->locale . '.mo', $fallback_locale . '.mo', $mofile );
+				$fallback_mofile = str_replace( $this->locale . '.mo', $fallback_locale . '.mo', $mofile );
 
-				if ( ! is_readable( $mofile ) ) {
-					// fallback mofile not found
-					return false;
-				} else {
+				if ( is_readable( $fallback_mofile ) ) {
 					// load fallback mofile
-					load_textdomain( $domain, $mofile );
+					load_textdomain( $domain, $fallback_mofile );
 
 					// return true to skip the loading of the originally requested file
 					return true;


### PR DESCRIPTION
If the filter 'fallback_locale' is used and multiple locales
are added to check for the old code would exit if the first
mo-file is not found. Now the foreach loop continues and
tries the next mo-file.

Is a mo-file found the function returns true to exit otherwise
it continues and will return false if no new mo-file is found

Each iteration the variable `$mofile` is overwritten and the `str_replace`
operation would not work.
